### PR TITLE
Indicate allowed method using http status and Allow header

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,10 +93,11 @@ app.get("/settings", (req, res) => {
 });
 
 app.get("/rpc", (req, res) => {
-  res.send({
-    description:
-      "Please use the HTTP POST method to proceed. For more details, refer to our documentation.",
-  });
+    res.status(405).set("Allow", "POST")
+        .send({
+            description:
+            "Please use the HTTP POST method to proceed. For more details, refer to our documentation.",
+        });
 });
 async function addToQueue(request, response) {
   async function work() {


### PR DESCRIPTION
I think this endpoint is just a service, and that it is unlikely to break anything by adjusting the response status to the semantically correct one (as well as adding info for machines in the `Allow` header).